### PR TITLE
Added method to call pyhtml from a webroute

### DIFF
--- a/MicroWebSrv2/mods/PyhtmlTemplate.py
+++ b/MicroWebSrv2/mods/PyhtmlTemplate.py
@@ -50,12 +50,14 @@ class PyhtmlTemplate :
     def ReturnTemplate(self, microWebSrv2, request, filepath):
         if not filepath:
             request.Response.ReturnNotFound()
+            return
 
         try :
             with open(filepath, 'r') as file :
                 code = file.read()
         except :
             request.Response.ReturnForbidden()
+            return
 
         try :
             self._pyGlobalVars['Request'] = request


### PR DESCRIPTION
Hi,
I'm not sure if this will make it in in it's current form, but to explain what I'm trying to do
With the old MicroWebSrv there was the ability to serve out a pyhtml template from a webroute with something like
```
httpResponse.WriteResponsePyHTMLFile(
    filepath='ServerApp/Views/home.pyhtml',
    vars=vars
    )
```

I couldn't see a simple way of doing this with the newer framework
It handles requests where someone just asks for a .pyhtml file directly in the request
and where the file is located under the root www directory

so with the code changes I've made in this pull request you can now do the following

``` python
@WebRoute(GET, '/test1')
def test1(microWebSrv2, request):
    filepath = 'ServerApp/Views/home.pyhtml'

    # module instance
    pyhtmlmod = microWebSrv2._modules['PyhtmlTemplate']
    pyhtmlmod.ReturnTemplate(microWebSrv2, request, filepath)
```
So the idea is you can pick different templates for a given route at the code level or have a template on a route not ending with .pyhtml

All I've done with the below change is split the function up and decrease the indent a bit, but functionally it's the same

I'm not sure if this is the most elegant way of handling this sort of thing or if there's a better way
any feedback would be appreciated
