### PR TITLE
Support bound methods as handlers

### DIFF
--- a/MicroWebSrv2/httpResponse.py
+++ b/MicroWebSrv2/httpResponse.py
@@ -541,7 +541,7 @@ class HttpResponse :
 
     @OnSent.setter
     def OnSent(self, value) :
-        if type(value) is not type(lambda x:x) :
+        if not callable(value) :
             raise ValueError('"OnSent" must be a function.')
         self._onSent = value
 

--- a/MicroWebSrv2/microWebSrv2.py
+++ b/MicroWebSrv2/microWebSrv2.py
@@ -534,7 +534,7 @@ class MicroWebSrv2 :
 
     @OnLogging.setter
     def OnLogging(self, value) :
-        if type(value) is not type(lambda x:x) :
+        if not callable(value) :
             raise ValueError('"OnLogging" must be a function.')
         self._onLogging = value
 

--- a/MicroWebSrv2/mods/WebSockets.py
+++ b/MicroWebSrv2/mods/WebSockets.py
@@ -63,7 +63,7 @@ class WebSockets :
 
     @OnWebSocketProtocol.setter
     def OnWebSocketProtocol(self, value) :
-        if type(value) is not type(lambda x:x) :
+        if not callable(value):
             raise ValueError('"OnWebSocketProtocol" must be a function.')
         self._onWebSocketProtocol = value
 
@@ -75,7 +75,7 @@ class WebSockets :
 
     @OnWebSocketAccepted.setter
     def OnWebSocketAccepted(self, value) :
-        if type(value) is not type(lambda x:x) :
+        if not callable(value):
             raise ValueError('"OnWebSocketAccepted" must be a function.')
         self._onWebSocketAccepted = value
 
@@ -444,7 +444,7 @@ class WebSocket :
 
     @OnTextMessage.setter
     def OnTextMessage(self, value) :
-        if type(value) is not type(lambda x:x) :
+        if not callable(value) :
             raise ValueError('"OnTextMessage" must be a function.')
         self._onTextMsg = value
 
@@ -456,7 +456,7 @@ class WebSocket :
 
     @OnBinaryMessage.setter
     def OnBinaryMessage(self, value) :
-        if type(value) is not type(lambda x:x) :
+        if not callable(value) :
             raise ValueError('"OnBinaryMessage" must be a function.')
         self._onBinMsg = value
 
@@ -468,7 +468,7 @@ class WebSocket :
 
     @OnClosed.setter
     def OnClosed(self, value) :
-        if type(value) is not type(lambda x:x) :
+        if not callable(value) :
             raise ValueError('"OnClosed" must be a function.')
         self._onClosed = value
 

--- a/MicroWebSrv2/webRoute.py
+++ b/MicroWebSrv2/webRoute.py
@@ -12,7 +12,7 @@ import re
 
 def WebRoute(method=None, routePath=None, name=None) :
 
-    if type(method) is type(lambda x:x) and not routePath :
+    if callable(method) and not routePath :
         raise ValueError('[@WebRoute] arguments are required for this decorator.')
     
     def decorated(handler) :
@@ -28,7 +28,7 @@ def WebRoute(method=None, routePath=None, name=None) :
 # ============================================================================
 
 def RegisterRoute(handler, method, routePath, name=None) :
-    if type(handler) is not type(lambda x:x) :
+    if not callable(handler) :
         raise ValueError('"handler" must be a function.')
     if not isinstance(method, str) or len(method) == 0 :
         raise ValueError('"method" requires a not empty string.')


### PR DESCRIPTION
By switching from `type(lambda x:x)` to using the `callable` checker, bound methods can now be used as callbacks.

This is useful in cases where the server object is an attribute of another object, and you want to use the parent object's methods as server handlers.