### PR TITLE
Adapt to ports/unix MicroPython using select.poll

### DIFF
--- a/MicroWebSrv2/libs/XAsyncSockets.py
+++ b/MicroWebSrv2/libs/XAsyncSockets.py
@@ -3,10 +3,17 @@ The MIT License (MIT)
 Copyright © 2019 Jean-Christophe Bos & HC² (www.hc2.fr)
 """
 
+import sys
+_IS_MICROPYTHON = sys.implementation.name == 'micropython'
 
 from   _thread  import allocate_lock, start_new_thread
 from   time     import sleep
-from   select   import select
+if _IS_MICROPYTHON:
+    from select import poll
+    import select
+    import struct
+else:
+    from select import select
 import socket
 import ssl
 
@@ -30,6 +37,7 @@ class XAsyncSocketsPool :
         self._processing   = False
         self._threadsCount = 0
         self._opLock       = allocate_lock()
+        if _IS_MICROPYTHON: self._poll = poll()
         self._asyncSockets = { }
         self._readList     = [ ]
         self._writeList    = [ ]
@@ -107,29 +115,56 @@ class XAsyncSocketsPool :
         self._incThreadsCount()
         timeSec = perf_counter()
         while self._processing :
+            if _IS_MICROPYTHON:
+                for socket in self._readList:
+                    self._poll.register(socket, select.POLLIN)
+                for socket in self._writeList:
+                    self._poll.register(socket, select.POLLOUT)
             try :
                 try :
-                    rd, wr, ex = select( self._readList,
-                                         self._writeList,
-                                         self._readList,
-                                         self._CHECK_SEC_INTERVAL )
+                    if _IS_MICROPYTHON:
+                        ready = self._poll.poll(int(self._CHECK_SEC_INTERVAL * 1000))
+                    else:
+                        rd, wr, ex = select( self._readList,
+                                             self._writeList,
+                                             self._readList,
+                                             self._CHECK_SEC_INTERVAL )
                 except KeyboardInterrupt as ex :
                     raise ex
-                except :
+                except Exception as ex:
                     continue
                 if not self._processing :
                     break
-                for socketsList in ex, wr, rd :
-                    for socket in socketsList :
+                if _IS_MICROPYTHON:
+                    for socket, mask in ready :
+                        if (0x20) & mask:
+                            self._poll.unregister(socket)
+                            continue
                         asyncSocket = self._asyncSockets.get(id(socket), None)
                         if asyncSocket and self._socketListAdd(socket, self._handlingList) :
-                            if socketsList is ex :
-                                asyncSocket.OnExceptionalCondition()
-                            elif socketsList is wr :
-                                asyncSocket.OnReadyForWriting()
-                            else :
+                            # POLLIN | POLLRDNORM | POLLRDBAND | POLLPRI
+                            if ((select.POLLIN | 0x40 | 0x80 | 0x2) & mask):
                                 asyncSocket.OnReadyForReading()
+                            # POLLOUT | POLLWRNORM | POLLWRBAND
+                            elif ((select.POLLOUT | 0x100 | 0x200) & mask):
+                                asyncSocket.OnReadyForWriting()
+                            # POLLNVAL
+                            else:
+                                asyncSocket.OnExceptionalCondition()
                             self._socketListRemove(socket, self._handlingList)
+                        self._poll.unregister(socket)
+                else:
+                    for socketsList in ex, wr, rd :
+                        for socket in socketsList :
+                            asyncSocket = self._asyncSockets.get(id(socket), None)
+                            if asyncSocket and self._socketListAdd(socket, self._handlingList) :
+                                if socketsList is ex :
+                                    asyncSocket.OnExceptionalCondition()
+                                elif socketsList is wr :
+                                    asyncSocket.OnReadyForWriting()
+                                else :
+                                    asyncSocket.OnReadyForReading()
+                                self._socketListRemove(socket, self._handlingList)
                 sec = perf_counter()
                 if sec > timeSec + self._CHECK_SEC_INTERVAL :
                     timeSec = sec
@@ -372,7 +407,10 @@ class XAsyncTCPServer(XAsyncSocket) :
             raise XAsyncTCPServerException('Create : Cannot open socket (no enought memory).')
         try :
             srvSocket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            srvSocket.bind(srvAddr)
+            if _IS_MICROPYTHON:
+                srvSocket.bind(socket.getaddrinfo(srvAddr[0], srvAddr[1])[0][-1])
+            else:
+                srvSocket.bind(srvAddr)
             srvSocket.listen(srvBacklog)
         except :
             raise XAsyncTCPServerException('Create : Error to binding the TCP server on this address.')
@@ -401,6 +439,12 @@ class XAsyncTCPServer(XAsyncSocket) :
     def OnReadyForReading(self) :
         try :
             cliSocket, cliAddr = self._socket.accept()
+            if _IS_MICROPYTHON:
+                # b'\x02\x00\x89L\x7f\x00\x00\x01'
+                address = ".".join([str(byte[0])
+                                    for byte in struct.unpack('ssss', cliAddr[4:8])])
+                port = struct.unpack('H', cliAddr[2:4])[0]
+                cliAddr = (address, port)
         except :
             return
         recvBufSlot = self._bufSlots.GetAvailableSlot()

--- a/MicroWebSrv2/libs/XAsyncSockets.py
+++ b/MicroWebSrv2/libs/XAsyncSockets.py
@@ -5,6 +5,7 @@ Copyright © 2019 Jean-Christophe Bos & HC² (www.hc2.fr)
 
 import sys
 _IS_MICROPYTHON = sys.implementation.name == 'micropython'
+_IS_MICROPYTHON_LINUX = _IS_MICROPYTHON and (sys.platform == 'linux')
 
 from   _thread  import allocate_lock, start_new_thread
 from   time     import sleep
@@ -439,7 +440,7 @@ class XAsyncTCPServer(XAsyncSocket) :
     def OnReadyForReading(self) :
         try :
             cliSocket, cliAddr = self._socket.accept()
-            if _IS_MICROPYTHON:
+            if _IS_MICROPYTHON_LINUX:   # TODO Resolve ports/unix dependency
                 # b'\x02\x00\x89L\x7f\x00\x00\x01'
                 address = ".".join([str(byte[0])
                                     for byte in struct.unpack('ssss', cliAddr[4:8])])

--- a/main.py
+++ b/main.py
@@ -163,8 +163,16 @@ mws2 = MicroWebSrv2()
 # For embedded MicroPython, use a very light configuration,
 mws2.SetEmbeddedConfig()
 
-# All pages not found will be redirected to the home '/',
-mws2.NotFoundURL = '/'
+# mws2.RootPath = '/flash/www' # E.g., MicroPython
+# Confirm that RootPath will resolve for home URL
+HOME = '/'
+if not mws2.ResolvePhysicalPath(HOME):
+    raise MicroWebSrv2Exception(
+        "RootPath '%s' does not resolve with URL '%s'" % (mws2.RootPath, HOME)
+    )
+
+# All pages not found will be redirected to the home,
+mws2.NotFoundURL = HOME
 
 # Starts the server as easily as possible in managed mode,
 mws2.StartManaged()


### PR DESCRIPTION
Thanks, Jean-Christophe, for this great web server. It makes MicroPython very valuable, especially for our application.

The default build of ports/unix MicroPython does not provide select.poll. For consistency, this pull request replaces select.select with select.poll for all MicroPython ports. The CPython execution remains unchanged with select.select.

It has been tested using the demo application on CPython, and MicroPython ports/unix and ports/stm32.

The second commit changes main.py to warn when / fails to resolve with the default RootPath.