### PR TITLE
Handle non-standard ports in wstest.html

### DIFF
--- a/www/wstest.html
+++ b/www/wstest.html
@@ -20,12 +20,20 @@
 
 		function testWebSocket()
 		{
-			var scheme
+			var scheme, defaultPort
 			if (window.location.protocol == 'https:')
+			{
 				scheme = 'wss:';
+				defaultPort = 443;
+			}
 			else
+			{
 				scheme = 'ws:';
+				defaultPort = 80;
+			}
 			var wsUri = scheme + '//' + window.location.hostname;
+			if (window.location.port !== defaultPort)
+				wsUri += ':' + window.location.port;
 			writeToScreen("Connecting to " + wsUri + "...")
 			websocket           = new WebSocket(wsUri);
 			websocket.onopen    = function(evt) { onOpen    (evt) };


### PR DESCRIPTION
If the main server is not running on a standard port, wstest.html won't work out of the box. This change adds the custom port if one is in use.