### PR TITLE
Makes the route resolver pattern compatible with MicroPython's re

### DIFF
--- a/MicroWebSrv2/webRoute.py
+++ b/MicroWebSrv2/webRoute.py
@@ -54,7 +54,7 @@ def RegisterRoute(handler, method, routePath, name=None) :
                     if not argName :
                         raise Exception
                     argNames.append(argName)
-                    regex += '/([\\w.]*)'
+                    regex += '/([A-Za-z0-9_.]*)'
                 else :
                     regex += '/' + part
         regex = re.compile(regex + '$')


### PR DESCRIPTION
MicroPython does not support named classes within `[...]` (i.e. no `[\\w]` or `[\\s]` )

Fixes #38