### PR TITLE
tckt22: add 'include' instruction to pyhtml template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1362,6 +1362,7 @@ except KeyboardInterrupt :
       | ELIF        | `{{ elif` *Python condition* `}}` *html bloc* `{{ end }}`                 |
       | ELSE        | `{{ else }}` *html bloc* `{{ end }}`                                      |
       | FOR         | `{{ for` *identifier* `in` *Python iterator* `}}` *html bloc* `{{ end }}` |
+      | INCLUDE     | `{{ include` *file.pyhtml* `}}` |
       | Expression  | `{{` *Python expression* `}}`                                             |
 
       :cyclone: See the **[test.pyhtml](https://github.com/jczic/MicroWebSrv2/blob/master/www/test.pyhtml)** page for the example:


### PR DESCRIPTION
I switched to MicroWebSrv2 from Flask when I needed to develop an embedded web app.  The inability to do 'include' felt like a major handicap to me -- I like to have the header menu in its own file and include it in every page, for example.  The changes in this PR have been working well for me; presumably they'd be useful for some other users of MWS2.