### PR TITLE
Fix a bug in XAsyncSockets.py

### DIFF
--- a/MicroWebSrv2/libs/XAsyncSockets.py
+++ b/MicroWebSrv2/libs/XAsyncSockets.py
@@ -827,7 +827,7 @@ class XAsyncTCPClient(XAsyncSocket) :
     @property
     def IsSSL(self) :
         return ( hasattr(ssl, 'SSLContext') and \
-                 isinstance(self._socket, ssl.SSLSocket) )
+                 isinstance(self._socket, ssl.SSLContext) )
 
     @property
     def SendingBuffer(self) :


### PR DESCRIPTION
The bug is in function IsSSL where the _socket object is tested to be an instance of SSLSocket. The correct is to test if the object is of class SSLContext.

https://github.com/jczic/MicroWebSrv2/issues/95

The SSLSocket attribute is not available in micropython for port esp32 and when initiating a simple GET crashes the server. 

Unhandled exception in thread started by <bound_method>
Traceback (most recent call last):
  File "MicroWebSrv2/libs/XAsyncSockets.py", line 131, in _processWaitEvents
  File "MicroWebSrv2/libs/XAsyncSockets.py", line 587, in OnReadyForReading
  File "MicroWebSrv2/libs/XAsyncSockets.py", line 830, in IsSSL
AttributeError: 'module' object has no attribute 'SSLSocket'